### PR TITLE
Revert "Fully qualify libEGL.so.1, libEGLESv2.so.2 libraries"

### DIFF
--- a/src/core/surface_factory_qt.cpp
+++ b/src/core/surface_factory_qt.cpp
@@ -71,13 +71,13 @@ base::NativeLibrary LoadLibrary(const base::FilePath& filename) {
 bool SurfaceFactoryQt::LoadEGLGLES2Bindings(AddGLLibraryCallback add_gl_library, SetGLGetProcAddressProcCallback set_gl_get_proc_address)
 {
     base::FilePath libEGLPath = QtWebEngineCore::toFilePath(QT_LIBDIR_EGL);
-    libEGLPath = libEGLPath.Append("libEGL.so.1");
+    libEGLPath = libEGLPath.Append("libEGL.so");
     base::NativeLibrary eglLibrary = LoadLibrary(libEGLPath);
     if (!eglLibrary)
         return false;
 
     base::FilePath libGLES2Path = QtWebEngineCore::toFilePath(QT_LIBDIR_GLES2);
-    libGLES2Path = libGLES2Path.Append("libGLESv2.so.2");
+    libGLES2Path = libGLES2Path.Append("libGLESv2.so");
     base::NativeLibrary gles2Library = LoadLibrary(libGLES2Path);
     if (!gles2Library)
         return false;


### PR DESCRIPTION
This reverts commit d07fba149ddc6df4cbc99d31b1edb17331fcfe53.
For some obscure reason, having this method fail on our devices
improves the compatibility with our EGL libraries.
Some more investigation is needed on that.
