### PR TITLE
WebEngineSettings: Add a "standardFontFamily" property to be able to …

### DIFF
--- a/src/webengine/api/qquickwebenginesettings.cpp
+++ b/src/webengine/api/qquickwebenginesettings.cpp
@@ -230,6 +230,10 @@ QString QQuickWebEngineSettings::luneOSIdentifier() const
 {
     return d_ptr->luneOSIdentifier();
 }
+QString QQuickWebEngineSettings::standardFontFamily() const
+{
+    return d_ptr->fontFamily(WebEngineSettings::StandardFont);;
+}
 
 
 void QQuickWebEngineSettings::setAutoLoadImages(bool on)
@@ -353,6 +357,14 @@ void QQuickWebEngineSettings::setLuneOSIdentifier(QString identifier)
     d_ptr->setLuneOSIdentifier(identifier);
     if (oldLuneOSIdentifier.compare(identifier))
         Q_EMIT luneOSIdentifierChanged();
+}
+
+void QQuickWebEngineSettings::setStandardFontFamily(QString fontFamily)
+{
+    const QString oldStandardFontFamily = d_ptr->fontFamily(WebEngineSettings::StandardFont);
+    d_ptr->setFontFamily(WebEngineSettings::StandardFont, fontFamily);
+    if (oldStandardFontFamily.compare(fontFamily))
+        Q_EMIT standardFontFamilyChanged();
 }
 
 void QQuickWebEngineSettings::setParentSettings(QQuickWebEngineSettings *parentSettings)

--- a/src/webengine/api/qquickwebenginesettings_p.h
+++ b/src/webengine/api/qquickwebenginesettings_p.h
@@ -75,6 +75,8 @@ class Q_WEBENGINE_PRIVATE_EXPORT QQuickWebEngineSettings : public QObject {
     Q_PROPERTY(bool palmServiceBridgeEnabled READ palmServiceBridgeEnabled WRITE setPalmServiceBridgeEnabled NOTIFY palmServiceBridgeEnabledChanged)
     Q_PROPERTY(bool luneOSPrivileged READ luneOSPrivileged WRITE setLuneOSPrivileged NOTIFY luneOSPrivilegedChanged)
     Q_PROPERTY(QString luneOSIdentifier READ luneOSIdentifier WRITE setLuneOSIdentifier NOTIFY luneOSIdentifierChanged)
+    Q_PROPERTY(QString standardFontFamily READ standardFontFamily WRITE setStandardFontFamily NOTIFY standardFontFamilyChanged)
+
 
 public:
     ~QQuickWebEngineSettings();
@@ -94,6 +96,7 @@ public:
     bool palmServiceBridgeEnabled() const;
     bool luneOSPrivileged() const;
     QString luneOSIdentifier() const;
+    QString standardFontFamily() const;
 
     void setAutoLoadImages(bool on);
     void setJavascriptEnabled(bool on);
@@ -110,6 +113,7 @@ public:
     void setPalmServiceBridgeEnabled(bool on);
     void setLuneOSPrivileged(bool on);
     void setLuneOSIdentifier(QString identifier);
+    void setStandardFontFamily(QString fontFamily);
 
 signals:
     void autoLoadImagesChanged();
@@ -127,6 +131,7 @@ signals:
     void palmServiceBridgeEnabledChanged();
     void luneOSPrivilegedChanged();
     void luneOSIdentifierChanged();
+    void standardFontFamilyChanged();
 
 private:
     explicit QQuickWebEngineSettings(QQuickWebEngineSettings *parentSettings = 0);


### PR DESCRIPTION
…setup Prelude

This is mainly intended to fill the gap left by Qt for this setting, and should be replaced by official Qt properties as soon as they appear upstream.

Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
