### PR TITLE
Tofe/work

### DIFF
--- a/examples/webengine/quicknanobrowser/BrowserWindow.qml
+++ b/examples/webengine/quicknanobrowser/BrowserWindow.qml
@@ -348,6 +348,35 @@ ApplicationWindow {
                     }
                     request.accept()
                 }
+
+                onRenderProcessTerminated: {
+                    var status = ""
+                    switch (terminationStatus) {
+                    case WebEngineView.NormalTerminationStatus:
+                        status = "(normal exit)"
+                        break;
+                    case WebEngineView.AbnormalTerminationStatus:
+                        status = "(abnormal exit)"
+                        break;
+                    case WebEngineView.CrashedTerminationStatus:
+                        status = "(crashed)"
+                        break;
+                    case WebEngineView.KilledTerminationStatus:
+                        status = "(killed)"
+                        break;
+                    }
+
+                    print("Render process exited with code " + exitCode + " " + status)
+                    reloadTimer.running = true
+                }
+
+                Timer {
+                    id: reloadTimer
+                    interval: 0
+                    running: false
+                    repeat: false
+                    onTriggered: currentWebView.reload()
+                }
             }
         }
     }

--- a/examples/webenginewidgets/browser/browser.pro
+++ b/examples/webenginewidgets/browser/browser.pro
@@ -1,6 +1,7 @@
 TEMPLATE = app
 TARGET = browser
 QT += webenginewidgets network widgets printsupport
+CONFIG += c++11
 
 qtHaveModule(uitools):!embedded: QT += uitools
 else: DEFINES += QT_NO_UITOOLS

--- a/examples/webenginewidgets/browser/webview.cpp
+++ b/examples/webenginewidgets/browser/webview.cpp
@@ -67,6 +67,7 @@
 
 #include <QtCore/QDebug>
 #include <QtCore/QBuffer>
+#include <QtCore/QTimer>
 
 WebPage::WebPage(QWebEngineProfile *profile, QObject *parent)
     : QWebEnginePage(profile, parent)
@@ -314,6 +315,27 @@ WebView::WebView(QWidget* parent)
             this, SLOT(setProgress(int)));
     connect(this, SIGNAL(loadFinished(bool)),
             this, SLOT(loadFinished(bool)));
+    connect(this, &QWebEngineView::renderProcessTerminated,
+            [=](QWebEnginePage::RenderProcessTerminationStatus termStatus, int statusCode) {
+        const char *status = "";
+        switch (termStatus) {
+        case QWebEnginePage::NormalTerminationStatus:
+            status = "(normal exit)";
+            break;
+        case QWebEnginePage::AbnormalTerminationStatus:
+            status = "(abnormal exit)";
+            break;
+        case QWebEnginePage::CrashedTerminationStatus:
+            status = "(crashed)";
+            break;
+        case QWebEnginePage::KilledTerminationStatus:
+            status = "(killed)";
+            break;
+        }
+
+        qInfo() << "Render process exited with code" << statusCode << status;
+        QTimer::singleShot(0, [this] { reload(); });
+    });
 }
 
 void WebView::setPage(WebPage *_page)

--- a/src/core/common/qt_messages.h
+++ b/src/core/common/qt_messages.h
@@ -31,6 +31,9 @@ IPC_MESSAGE_ROUTED1(QtRenderViewObserver_FetchDocumentMarkup,
 IPC_MESSAGE_ROUTED1(QtRenderViewObserver_FetchDocumentInnerText,
                     uint64 /* requestId */)
 
+IPC_MESSAGE_ROUTED1(QtRenderViewObserver_SetBackgroundColor,
+                    uint32 /* color */)
+
 IPC_MESSAGE_ROUTED1(WebChannelIPCTransport_Message, std::vector<char> /*binaryJSON*/)
 
 // User scripts messages

--- a/src/core/render_widget_host_view_qt.cpp
+++ b/src/core/render_widget_host_view_qt.cpp
@@ -580,8 +580,11 @@ void RenderWidgetHostViewQt::ImeCompositionRangeChanged(const gfx::Range&, const
     QT_NOT_YET_IMPLEMENTED
 }
 
-void RenderWidgetHostViewQt::RenderProcessGone(base::TerminationStatus, int)
+void RenderWidgetHostViewQt::RenderProcessGone(base::TerminationStatus terminationStatus,
+                                               int exitCode)
 {
+    m_adapterClient->renderProcessTerminated(
+                m_adapterClient->renderProcessExitStatus(terminationStatus), exitCode);
     Destroy();
 }
 

--- a/src/core/render_widget_host_view_qt.cpp
+++ b/src/core/render_widget_host_view_qt.cpp
@@ -36,6 +36,7 @@
 
 #include "render_widget_host_view_qt.h"
 
+#include "common/qt_messages.h"
 #include "browser_accessibility_manager_qt.h"
 #include "browser_accessibility_qt.h"
 #include "chromium_overrides.h"
@@ -408,6 +409,14 @@ gfx::Rect RenderWidgetHostViewQt::GetViewBounds() const
     gfx::Point p1(floor(p.x() / s), floor(p.y() / s));
     gfx::Point p2(ceil(p.right() /s), ceil(p.bottom() / s));
     return gfx::BoundingRect(p1, p2);
+}
+
+void RenderWidgetHostViewQt::SetBackgroundColor(SkColor color) {
+    RenderWidgetHostViewBase::SetBackgroundColor(color);
+    // Set the background of the compositor if necessary
+    m_delegate->setClearColor(toQt(color));
+    // Set the background of the blink::FrameView
+    m_host->Send(new QtRenderViewObserver_SetBackgroundColor(m_host->GetRoutingID(), color));
 }
 
 // Return value indicates whether the mouse is locked successfully or not.

--- a/src/core/render_widget_host_view_qt.h
+++ b/src/core/render_widget_host_view_qt.h
@@ -125,6 +125,7 @@ public:
     virtual void Hide() Q_DECL_OVERRIDE;
     virtual bool IsShowing() Q_DECL_OVERRIDE;
     virtual gfx::Rect GetViewBounds() const Q_DECL_OVERRIDE;
+    virtual void SetBackgroundColor(SkColor color) Q_DECL_OVERRIDE;
     virtual bool LockMouse() Q_DECL_OVERRIDE;
     virtual void UnlockMouse() Q_DECL_OVERRIDE;
     virtual void WasShown() Q_DECL_OVERRIDE;

--- a/src/core/render_widget_host_view_qt_delegate.h
+++ b/src/core/render_widget_host_view_qt_delegate.h
@@ -96,6 +96,7 @@ public:
     virtual void move(const QPoint &) = 0;
     virtual void inputMethodStateChanged(bool editorVisible) = 0;
     virtual void setTooltip(const QString &) = 0;
+    virtual void setClearColor(const QColor &color) = 0;
 };
 
 } // namespace QtWebEngineCore

--- a/src/core/renderer/qt_render_view_observer.cpp
+++ b/src/core/renderer/qt_render_view_observer.cpp
@@ -65,6 +65,11 @@ void QtRenderViewObserver::onFetchDocumentInnerText(quint64 requestId)
         render_view()->GetWebView()->mainFrame()->contentAsText(std::numeric_limits<std::size_t>::max())));
 }
 
+void QtRenderViewObserver::onSetBackgroundColor(quint32 color)
+{
+    render_view()->GetWebView()->setBaseBackgroundColor(color);
+}
+
 void QtRenderViewObserver::OnFirstVisuallyNonEmptyLayout()
 {
     Send(new QtRenderViewObserverHost_DidFirstVisuallyNonEmptyLayout(routing_id()));
@@ -76,6 +81,7 @@ bool QtRenderViewObserver::OnMessageReceived(const IPC::Message& message)
     IPC_BEGIN_MESSAGE_MAP(QtRenderViewObserver, message)
         IPC_MESSAGE_HANDLER(QtRenderViewObserver_FetchDocumentMarkup, onFetchDocumentMarkup)
         IPC_MESSAGE_HANDLER(QtRenderViewObserver_FetchDocumentInnerText, onFetchDocumentInnerText)
+        IPC_MESSAGE_HANDLER(QtRenderViewObserver_SetBackgroundColor, onSetBackgroundColor)
         IPC_MESSAGE_UNHANDLED(handled = false)
     IPC_END_MESSAGE_MAP()
     return handled;

--- a/src/core/renderer/qt_render_view_observer.h
+++ b/src/core/renderer/qt_render_view_observer.h
@@ -47,6 +47,7 @@ public:
 private:
     void onFetchDocumentMarkup(quint64 requestId);
     void onFetchDocumentInnerText(quint64 requestId);
+    void onSetBackgroundColor(quint32 color);
 
     void OnFirstVisuallyNonEmptyLayout() Q_DECL_OVERRIDE;
 

--- a/src/core/type_conversion.h
+++ b/src/core/type_conversion.h
@@ -122,6 +122,11 @@ inline QColor toQt(const SkColor &c)
     return QColor(SkColorGetR(c), SkColorGetG(c), SkColorGetB(c), SkColorGetA(c));
 }
 
+inline SkColor toSk(const QColor &c)
+{
+    return c.rgba();
+}
+
 inline QMatrix4x4 toQt(const SkMatrix44 &m)
 {
     QMatrix4x4 qtMatrix(

--- a/src/core/web_contents_adapter.cpp
+++ b/src/core/web_contents_adapter.cpp
@@ -887,4 +887,36 @@ void WebContentsAdapter::setWebChannel(QWebChannel *channel)
     channel->connectTo(d->webChannelTransport.get());
 }
 
+WebContentsAdapterClient::RenderProcessTerminationStatus
+WebContentsAdapterClient::renderProcessExitStatus(int terminationStatus) {
+    auto status = WebContentsAdapterClient::RenderProcessTerminationStatus(-1);
+    switch (terminationStatus) {
+    case base::TERMINATION_STATUS_NORMAL_TERMINATION:
+        status = WebContentsAdapterClient::NormalTerminationStatus;
+        break;
+    case base::TERMINATION_STATUS_ABNORMAL_TERMINATION:
+        status = WebContentsAdapterClient::AbnormalTerminationStatus;
+        break;
+    case base::TERMINATION_STATUS_PROCESS_WAS_KILLED:
+#if defined(OS_CHROMEOS)
+    case base::TERMINATION_STATUS_PROCESS_WAS_KILLED_BY_OOM:
+#endif
+        status = WebContentsAdapterClient::KilledTerminationStatus;
+        break;
+    case base::TERMINATION_STATUS_PROCESS_CRASHED:
+#if defined(OS_ANDROID)
+    case base::TERMINATION_STATUS_OOM_PROTECTED:
+#endif
+        status = WebContentsAdapterClient::CrashedTerminationStatus;
+        break;
+    case base::TERMINATION_STATUS_STILL_RUNNING:
+    case base::TERMINATION_STATUS_MAX_ENUM:
+        // should be unreachable since Chromium asserts status != TERMINATION_STATUS_STILL_RUNNING
+        // before calling this method
+        break;
+    }
+
+    return status;
+}
+
 } // namespace QtWebEngineCore

--- a/src/core/web_contents_adapter.cpp
+++ b/src/core/web_contents_adapter.cpp
@@ -850,6 +850,13 @@ void WebContentsAdapter::filesSelectedInChooser(const QStringList &fileList, Web
     rvh->FilesSelectedInChooser(toVector<content::FileChooserFileInfo>(files), static_cast<content::FileChooserParams::Mode>(mode));
 }
 
+void WebContentsAdapter::backgroundColorChanged()
+{
+    Q_D(WebContentsAdapter);
+    if (content::RenderWidgetHostView *rwhv = d->webContents->GetRenderWidgetHostView())
+        rwhv->SetBackgroundColor(toSk(d->adapterClient->backgroundColor()));
+}
+
 content::WebContents *WebContentsAdapter::webContents() const
 {
     Q_D(const WebContentsAdapter);

--- a/src/core/web_contents_adapter.h
+++ b/src/core/web_contents_adapter.h
@@ -121,6 +121,7 @@ public:
     void grantMouseLockPermission(bool granted);
 
     void dpiScaleChanged();
+    void backgroundColorChanged();
     QAccessibleInterface *browserAccessible();
     BrowserContextQt* browserContext();
     BrowserContextAdapter* browserContextAdapter();

--- a/src/core/web_contents_adapter_client.h
+++ b/src/core/web_contents_adapter_client.h
@@ -152,6 +152,7 @@ public:
     virtual void selectionChanged() = 0;
     virtual QRectF viewportRect() const = 0;
     virtual qreal dpiScale() const = 0;
+    virtual QColor backgroundColor() const = 0;
     virtual void loadStarted(const QUrl &provisionalUrl, bool isErrorPage = false) = 0;
     virtual void loadCommitted() = 0;
     virtual void loadVisuallyCommitted() = 0;

--- a/src/core/web_contents_adapter_client.h
+++ b/src/core/web_contents_adapter_client.h
@@ -133,6 +133,13 @@ public:
         Error
     };
 
+    enum RenderProcessTerminationStatus {
+        NormalTerminationStatus = 0,
+        AbnormalTerminationStatus,
+        CrashedTerminationStatus,
+        KilledTerminationStatus
+    };
+
     enum MediaRequestFlag {
         MediaNone = 0,
         MediaAudioCapture = 0x01,
@@ -186,6 +193,8 @@ public:
     virtual void showValidationMessage(const QRect &anchor, const QString &mainText, const QString &subText) = 0;
     virtual void hideValidationMessage() = 0;
     virtual void moveValidationMessage(const QRect &anchor) = 0;
+    RenderProcessTerminationStatus renderProcessExitStatus(int);
+    virtual void renderProcessTerminated(RenderProcessTerminationStatus terminationStatus, int exitCode) = 0;
 
     virtual void allowCertificateError(const QSharedPointer<CertificateErrorController> &errorController) = 0;
 

--- a/src/core/web_contents_view_qt.cpp
+++ b/src/core/web_contents_view_qt.cpp
@@ -53,8 +53,10 @@ void WebContentsViewQt::initialize(WebContentsAdapterClient* client)
     m_factoryClient = client;
 
     // Check if a RWHV was created before the initialization.
-    if (m_webContents->GetRenderWidgetHostView())
-        static_cast<RenderWidgetHostViewQt *>(m_webContents->GetRenderWidgetHostView())->setAdapterClient(client);
+    if (auto rwhv = static_cast<RenderWidgetHostViewQt *>(m_webContents->GetRenderWidgetHostView())) {
+        rwhv->setAdapterClient(client);
+        rwhv->SetBackgroundColor(toSk(client->backgroundColor()));
+    }
 }
 
 content::RenderWidgetHostViewBase* WebContentsViewQt::CreateViewForWidget(content::RenderWidgetHost* render_widget_host, bool is_guest_view_hack)
@@ -86,7 +88,8 @@ void WebContentsViewQt::RenderViewCreated(content::RenderViewHost* host)
 {
     // The render process is done creating the RenderView and it's ready to be routed
     // messages at this point.
-    host->GetView()->SetBackgroundColor(toSk(m_client->backgroundColor()));
+    if (m_client)
+        host->GetView()->SetBackgroundColor(toSk(m_client->backgroundColor()));
 }
 
 void WebContentsViewQt::CreateView(const gfx::Size& initial_size, gfx::NativeView context)

--- a/src/core/web_contents_view_qt.cpp
+++ b/src/core/web_contents_view_qt.cpp
@@ -82,6 +82,13 @@ content::RenderWidgetHostViewBase* WebContentsViewQt::CreateViewForPopupWidget(c
     return view;
 }
 
+void WebContentsViewQt::RenderViewCreated(content::RenderViewHost* host)
+{
+    // The render process is done creating the RenderView and it's ready to be routed
+    // messages at this point.
+    host->GetView()->SetBackgroundColor(toSk(m_client->backgroundColor()));
+}
+
 void WebContentsViewQt::CreateView(const gfx::Size& initial_size, gfx::NativeView context)
 {
     // This is passed through content::WebContents::CreateParams::context either as the native view's client

--- a/src/core/web_contents_view_qt.h
+++ b/src/core/web_contents_view_qt.h
@@ -81,7 +81,7 @@ public:
 
     virtual void SetPageTitle(const base::string16& title) Q_DECL_OVERRIDE { }
 
-    virtual void RenderViewCreated(content::RenderViewHost* host) Q_DECL_OVERRIDE { QT_NOT_YET_IMPLEMENTED }
+    virtual void RenderViewCreated(content::RenderViewHost* host) Q_DECL_OVERRIDE;
 
     virtual void RenderViewSwappedIn(content::RenderViewHost* host) Q_DECL_OVERRIDE { QT_NOT_YET_IMPLEMENTED }
 

--- a/src/webengine/api/qquickwebengineview.cpp
+++ b/src/webengine/api/qquickwebengineview.cpp
@@ -430,7 +430,8 @@ void QQuickWebEngineViewPrivate::adoptNewWindow(WebContentsAdapter *newWebConten
 
 void QQuickWebEngineViewPrivate::close()
 {
-    // Not implemented yet.
+    Q_Q(QQuickWebEngineView);
+    emit q->windowCloseRequested();
 }
 
 void QQuickWebEngineViewPrivate::requestFullScreen(bool fullScreen)

--- a/src/webengine/api/qquickwebengineview.cpp
+++ b/src/webengine/api/qquickwebengineview.cpp
@@ -808,6 +808,14 @@ void QQuickWebEngineViewPrivate::moveValidationMessage(const QRect &anchor)
     ui()->moveMessageBubble(anchor);
 }
 
+void QQuickWebEngineViewPrivate::renderProcessTerminated(
+        RenderProcessTerminationStatus terminationStatus, int exitCode)
+{
+    Q_Q(QQuickWebEngineView);
+    Q_EMIT q->renderProcessTerminated(static_cast<QQuickWebEngineView::RenderProcessTerminationStatus>(
+                                      renderProcessExitStatus(terminationStatus)), exitCode);
+}
+
 bool QQuickWebEngineView::isLoading() const
 {
     Q_D(const QQuickWebEngineView);

--- a/src/webengine/api/qquickwebengineview.cpp
+++ b/src/webengine/api/qquickwebengineview.cpp
@@ -104,6 +104,7 @@ QQuickWebEngineViewPrivate::QQuickWebEngineViewPrivate()
     , isLoading(false)
     , devicePixelRatio(QGuiApplication::primaryScreen()->devicePixelRatio())
     , m_dpiScale(1.0)
+    , m_backgroundColor(Qt::white)
 {
     // The gold standard for mobile web content is 160 dpi, and the devicePixelRatio expected
     // is the (possibly quantized) ratio of device dpi to 160 dpi.
@@ -308,6 +309,11 @@ QRectF QQuickWebEngineViewPrivate::viewportRect() const
 qreal QQuickWebEngineViewPrivate::dpiScale() const
 {
     return m_dpiScale;
+}
+
+QColor QQuickWebEngineViewPrivate::backgroundColor() const
+{
+    return m_backgroundColor;
 }
 
 void QQuickWebEngineViewPrivate::loadStarted(const QUrl &provisionalUrl, bool isErrorPage)
@@ -864,6 +870,34 @@ qreal QQuickWebEngineView::zoomFactor() const
     return d->adapter->currentZoomFactor();
 }
 
+/*!
+    \qmlproperty bool WebEngineView::backgroundColor
+    \since QtWebEngine 1.3
+
+    Sets this property to change the color of the WebEngineView's background,
+    behing the document's body. You can set it to "transparent" or to a translucent
+    color to see through the document, or you can set this color to match your
+    web content in an hybrid app to prevent the white flashes that may appear
+    during loading.
+
+    The default value is white.
+*/
+QColor QQuickWebEngineView::backgroundColor() const
+{
+    Q_D(const QQuickWebEngineView);
+    return d->m_backgroundColor;
+}
+
+void QQuickWebEngineView::setBackgroundColor(const QColor &color)
+{
+    Q_D(QQuickWebEngineView);
+    if (color == d->m_backgroundColor)
+        return;
+    d->m_backgroundColor = color;
+    d->ensureContentsAdapter();
+    d->adapter->backgroundColorChanged();
+    emit backgroundColorChanged();
+}
 
 bool QQuickWebEngineView::isFullScreen() const
 {

--- a/src/webengine/api/qquickwebengineview_p.h
+++ b/src/webengine/api/qquickwebengineview_p.h
@@ -255,6 +255,7 @@ Q_SIGNALS:
     Q_REVISION(1) void webChannelChanged();
     Q_REVISION(1) void backgroundColorChanged();
     Q_REVISION(1) void renderProcessTerminated(RenderProcessTerminationStatus terminationStatus, int exitCode);
+    Q_REVISION(1) void windowCloseRequested();
 
 protected:
     void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry);

--- a/src/webengine/api/qquickwebengineview_p.h
+++ b/src/webengine/api/qquickwebengineview_p.h
@@ -113,6 +113,7 @@ class Q_WEBENGINE_PRIVATE_EXPORT QQuickWebEngineView : public QQuickItem {
     Q_ENUMS(NewViewDestination);
     Q_ENUMS(Feature);
     Q_ENUMS(JavaScriptConsoleMessageLevel);
+    Q_ENUMS(RenderProcessTerminationStatus);
     Q_FLAGS(FindFlags);
 
 public:
@@ -191,6 +192,14 @@ public:
         ErrorMessageLevel
     };
 
+    // must match WebContentsAdapterClient::RenderProcessTerminationStatus
+    enum RenderProcessTerminationStatus {
+        NormalTerminationStatus = 0,
+        AbnormalTerminationStatus,
+        CrashedTerminationStatus,
+        KilledTerminationStatus
+    };
+
     enum FindFlag {
         FindBackward = 1,
         FindCaseSensitively = 2,
@@ -245,6 +254,7 @@ Q_SIGNALS:
     Q_REVISION(1) void profileChanged();
     Q_REVISION(1) void webChannelChanged();
     Q_REVISION(1) void backgroundColorChanged();
+    Q_REVISION(1) void renderProcessTerminated(RenderProcessTerminationStatus terminationStatus, int exitCode);
 
 protected:
     void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry);

--- a/src/webengine/api/qquickwebengineview_p.h
+++ b/src/webengine/api/qquickwebengineview_p.h
@@ -100,6 +100,7 @@ class Q_WEBENGINE_PRIVATE_EXPORT QQuickWebEngineView : public QQuickItem {
     Q_PROPERTY(QQuickWebEngineHistory *navigationHistory READ navigationHistory CONSTANT FINAL REVISION 1)
     Q_PROPERTY(QQmlWebChannel *webChannel READ webChannel WRITE setWebChannel NOTIFY webChannelChanged REVISION 1)
     Q_PROPERTY(QQmlListProperty<QQuickWebEngineScript> userScripts READ userScripts FINAL REVISION 1)
+    Q_PROPERTY(QColor backgroundColor READ backgroundColor WRITE setBackgroundColor NOTIFY backgroundColorChanged REVISION 1)
 
 #ifdef ENABLE_QML_TESTSUPPORT_API
     Q_PROPERTY(QQuickWebEngineTestSupport *testSupport READ testSupport WRITE setTestSupport FINAL)
@@ -129,6 +130,8 @@ public:
     bool isFullScreen() const;
     qreal zoomFactor() const;
     void setZoomFactor(qreal arg);
+    QColor backgroundColor() const;
+    void setBackgroundColor(const QColor &color);
 
     QQuickWebEngineViewExperimental *experimental() const;
 
@@ -241,7 +244,7 @@ Q_SIGNALS:
     Q_REVISION(1) void zoomFactorChanged(qreal arg);
     Q_REVISION(1) void profileChanged();
     Q_REVISION(1) void webChannelChanged();
-
+    Q_REVISION(1) void backgroundColorChanged();
 
 protected:
     void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry);

--- a/src/webengine/api/qquickwebengineview_p_p.h
+++ b/src/webengine/api/qquickwebengineview_p_p.h
@@ -167,6 +167,8 @@ public:
     virtual void showValidationMessage(const QRect &anchor, const QString &mainText, const QString &subText) Q_DECL_OVERRIDE;
     virtual void hideValidationMessage() Q_DECL_OVERRIDE;
     virtual void moveValidationMessage(const QRect &anchor) Q_DECL_OVERRIDE;
+    virtual void renderProcessTerminated(RenderProcessTerminationStatus terminationStatus,
+                                     int exitCode) Q_DECL_OVERRIDE;
 
     virtual QtWebEngineCore::BrowserContextAdapter *browserContextAdapter() Q_DECL_OVERRIDE;
 

--- a/src/webengine/api/qquickwebengineview_p_p.h
+++ b/src/webengine/api/qquickwebengineview_p_p.h
@@ -134,6 +134,7 @@ public:
     virtual void selectionChanged() Q_DECL_OVERRIDE { }
     virtual QRectF viewportRect() const Q_DECL_OVERRIDE;
     virtual qreal dpiScale() const Q_DECL_OVERRIDE;
+    virtual QColor backgroundColor() const Q_DECL_OVERRIDE;
     virtual void loadStarted(const QUrl &provisionalUrl, bool isErrorPage = false) Q_DECL_OVERRIDE;
     virtual void loadCommitted() Q_DECL_OVERRIDE;
     virtual void loadVisuallyCommitted() Q_DECL_OVERRIDE;
@@ -203,6 +204,7 @@ private:
     QScopedPointer<QtWebEngineCore::UIDelegatesManager> m_uIDelegatesManager;
     QList<QQuickWebEngineScript *> m_userScripts;
     qreal m_dpiScale;
+    QColor m_backgroundColor;
 };
 
 #ifndef QT_NO_ACCESSIBILITY

--- a/src/webengine/doc/src/qquickwebengineview_lgpl.qdoc
+++ b/src/webengine/doc/src/qquickwebengineview_lgpl.qdoc
@@ -496,6 +496,16 @@
 */
 
 /*!
+    \qmlsignal WebEngineView::windowCloseRequested()
+    \since QtWebEngine 1.2
+
+    This signal is emitted whenever the page requests the web browser window to be closed,
+    for example through the JavaScript \c{window.close()} call.
+
+    The corresponding handler is \c onWindowCloseRequested.
+*/
+
+/*!
     \qmlproperty enumeration WebEngineView::ErrorDomain
 
     This enumeration details various high-level error types.

--- a/src/webengine/render_widget_host_view_qt_delegate_quick.h
+++ b/src/webengine/render_widget_host_view_qt_delegate_quick.h
@@ -70,6 +70,8 @@ public:
     virtual void move(const QPoint&) Q_DECL_OVERRIDE { }
     virtual void inputMethodStateChanged(bool editorVisible) Q_DECL_OVERRIDE;
     virtual void setTooltip(const QString&) Q_DECL_OVERRIDE { }
+    // The QtQuick view doesn't have a backbuffer of its own and doesn't need this
+    virtual void setClearColor(const QColor &) Q_DECL_OVERRIDE { }
 
 protected:
     virtual void focusInEvent(QFocusEvent *event) Q_DECL_OVERRIDE;

--- a/src/webengine/render_widget_host_view_qt_delegate_quickwindow.h
+++ b/src/webengine/render_widget_host_view_qt_delegate_quickwindow.h
@@ -73,6 +73,7 @@ public:
     virtual void move(const QPoint &screenPos) Q_DECL_OVERRIDE;
     virtual void inputMethodStateChanged(bool) Q_DECL_OVERRIDE {}
     virtual void setTooltip(const QString &tooltip) Q_DECL_OVERRIDE;
+    virtual void setClearColor(const QColor &) Q_DECL_OVERRIDE { }
 
 private:
     QScopedPointer<RenderWidgetHostViewQtDelegate> m_realDelegate;

--- a/src/webenginewidgets/api/qwebenginepage.cpp
+++ b/src/webenginewidgets/api/qwebenginepage.cpp
@@ -841,6 +841,14 @@ void QWebEnginePagePrivate::moveValidationMessage(const QRect &anchor)
 #endif
 }
 
+void QWebEnginePagePrivate::renderProcessTerminated(RenderProcessTerminationStatus terminationStatus,
+                                                int exitCode)
+{
+    Q_Q(QWebEnginePage);
+    Q_EMIT q->renderProcessTerminated(static_cast<QWebEnginePage::RenderProcessTerminationStatus>(
+                                      terminationStatus), exitCode);
+}
+
 namespace {
 class SaveToClipboardFunctor
 {

--- a/src/webenginewidgets/api/qwebenginepage.cpp
+++ b/src/webenginewidgets/api/qwebenginepage.cpp
@@ -185,6 +185,7 @@ QWebEnginePagePrivate::QWebEnginePagePrivate(QWebEngineProfile *_profile)
     , view(0)
     , isLoading(false)
     , scriptCollection(new QWebEngineScriptCollectionPrivate(browserContextAdapter()->userScriptController(), adapter.data()))
+    , m_backgroundColor(Qt::white)
 {
     memset(actions, 0, sizeof(actions));
 }
@@ -245,6 +246,11 @@ QRectF QWebEnginePagePrivate::viewportRect() const
 qreal QWebEnginePagePrivate::dpiScale() const
 {
     return 1.0;
+}
+
+QColor QWebEnginePagePrivate::backgroundColor() const
+{
+    return m_backgroundColor;
 }
 
 void QWebEnginePagePrivate::loadStarted(const QUrl &provisionalUrl, bool isErrorPage)
@@ -530,6 +536,33 @@ void QWebEnginePage::setWebChannel(QWebChannel *channel)
 {
     Q_D(QWebEnginePage);
     d->adapter->setWebChannel(channel);
+}
+
+/*!
+    \property QWebEnginePage::backgroundColor
+    \brief the page's background color, behing the document's body.
+    \since 5.6
+
+    You can set it to Qt::transparent or to a translucent
+    color to see through the document, or you can set this color to match your
+    web content in an hybrid app to prevent the white flashes that may appear
+    during loading.
+
+    The default value is white.
+*/
+QColor QWebEnginePage::backgroundColor() const
+{
+    Q_D(const QWebEnginePage);
+    return d->m_backgroundColor;
+}
+
+void QWebEnginePage::setBackgroundColor(const QColor &color)
+{
+    Q_D(QWebEnginePage);
+    if (d->m_backgroundColor == color)
+        return;
+    d->m_backgroundColor = color;
+    d->adapter->backgroundColorChanged();
 }
 
 void QWebEnginePage::setView(QWidget *view)

--- a/src/webenginewidgets/api/qwebenginepage.h
+++ b/src/webenginewidgets/api/qwebenginepage.h
@@ -98,6 +98,7 @@ class QWEBENGINEWIDGETS_EXPORT QWebEnginePage : public QObject {
     Q_PROPERTY(QString title READ title)
     Q_PROPERTY(QUrl url READ url WRITE setUrl)
     Q_PROPERTY(QUrl iconUrl READ iconUrl)
+    Q_PROPERTY(QColor backgroundColor READ backgroundColor WRITE setBackgroundColor)
 
 public:
     enum WebAction {
@@ -236,6 +237,8 @@ public:
 
     QWebChannel *webChannel() const;
     void setWebChannel(QWebChannel *);
+    QColor backgroundColor() const;
+    void setBackgroundColor(const QColor &color);
 
 Q_SIGNALS:
     void loadStarted();

--- a/src/webenginewidgets/api/qwebenginepage.h
+++ b/src/webenginewidgets/api/qwebenginepage.h
@@ -175,6 +175,14 @@ public:
         ErrorMessageLevel
     };
 
+    // must match WebContentsAdapterClient::RenderProcessTerminationStatus
+    enum RenderProcessTerminationStatus {
+        NormalTerminationStatus = 0,
+        AbnormalTerminationStatus,
+        CrashedTerminationStatus,
+        KilledTerminationStatus
+    };
+
     explicit QWebEnginePage(QObject *parent = 0);
     QWebEnginePage(QWebEngineProfile *profile, QObject *parent = 0);
     ~QWebEnginePage();
@@ -255,6 +263,8 @@ Q_SIGNALS:
 
     void authenticationRequired(const QUrl &requestUrl, QAuthenticator *authenticator);
     void proxyAuthenticationRequired(const QUrl &requestUrl, QAuthenticator *authenticator, const QString &proxyHost);
+
+    void renderProcessTerminated(RenderProcessTerminationStatus terminationStatus, int exitCode);
 
     // Ex-QWebFrame signals
     void titleChanged(const QString &title);

--- a/src/webenginewidgets/api/qwebenginepage_p.h
+++ b/src/webenginewidgets/api/qwebenginepage_p.h
@@ -162,6 +162,8 @@ public:
     virtual void showValidationMessage(const QRect &anchor, const QString &mainText, const QString &subText) Q_DECL_OVERRIDE;
     virtual void hideValidationMessage() Q_DECL_OVERRIDE;
     virtual void moveValidationMessage(const QRect &anchor) Q_DECL_OVERRIDE;
+    virtual void renderProcessTerminated(RenderProcessTerminationStatus terminationStatus,
+                                     int exitCode) Q_DECL_OVERRIDE;
 
     virtual QtWebEngineCore::BrowserContextAdapter *browserContextAdapter() Q_DECL_OVERRIDE;
 

--- a/src/webenginewidgets/api/qwebenginepage_p.h
+++ b/src/webenginewidgets/api/qwebenginepage_p.h
@@ -129,6 +129,7 @@ public:
     virtual void selectionChanged() Q_DECL_OVERRIDE;
     virtual QRectF viewportRect() const Q_DECL_OVERRIDE;
     virtual qreal dpiScale() const Q_DECL_OVERRIDE;
+    virtual QColor backgroundColor() const Q_DECL_OVERRIDE;
     virtual void loadStarted(const QUrl &provisionalUrl, bool isErrorPage = false) Q_DECL_OVERRIDE;
     virtual void loadCommitted() Q_DECL_OVERRIDE;
     virtual void loadVisuallyCommitted() Q_DECL_OVERRIDE { }
@@ -181,6 +182,7 @@ public:
     QtWebEngineCore::WebEngineContextMenuData m_menuData;
     bool isLoading;
     QWebEngineScriptCollection scriptCollection;
+    QColor m_backgroundColor;
 
     mutable CallbackDirectory m_callbacks;
     mutable QAction *actions[QWebEnginePage::WebActionCount];

--- a/src/webenginewidgets/api/qwebengineview.cpp
+++ b/src/webenginewidgets/api/qwebengineview.cpp
@@ -86,6 +86,7 @@ void QWebEngineViewPrivate::bind(QWebEngineView *view, QWebEnginePage *page)
         QObject::connect(page, &QWebEnginePage::loadProgress, view, &QWebEngineView::loadProgress);
         QObject::connect(page, &QWebEnginePage::loadFinished, view, &QWebEngineView::loadFinished);
         QObject::connect(page, &QWebEnginePage::selectionChanged, view, &QWebEngineView::selectionChanged);
+        QObject::connect(page, &QWebEnginePage::renderProcessTerminated, view, &QWebEngineView::renderProcessTerminated);
     }
 }
 

--- a/src/webenginewidgets/api/qwebengineview.h
+++ b/src/webenginewidgets/api/qwebengineview.h
@@ -113,6 +113,8 @@ Q_SIGNALS:
     void selectionChanged();
     void urlChanged(const QUrl&);
     void iconUrlChanged(const QUrl&);
+    void renderProcessTerminated(QWebEnginePage::RenderProcessTerminationStatus terminationStatus,
+                             int exitCode);
 
 protected:
     virtual QWebEngineView *createWindow(QWebEnginePage::WebWindowType type);

--- a/src/webenginewidgets/render_widget_host_view_qt_delegate_widget.h
+++ b/src/webenginewidgets/render_widget_host_view_qt_delegate_widget.h
@@ -78,6 +78,7 @@ public:
     virtual void move(const QPoint &screenPos) Q_DECL_OVERRIDE;
     virtual void inputMethodStateChanged(bool editorVisible) Q_DECL_OVERRIDE;
     virtual void setTooltip(const QString &tooltip) Q_DECL_OVERRIDE;
+    virtual void setClearColor(const QColor &color) Q_DECL_OVERRIDE;
 
 protected:
     bool event(QEvent *event) Q_DECL_OVERRIDE;
@@ -98,6 +99,7 @@ private:
     QScopedPointer<QSGEngine> m_sgEngine;
     QScopedPointer<QSGAbstractRenderer> m_sgRenderer;
     bool m_isPopup;
+    QColor m_clearColor;
     QList<QMetaObject::Connection> m_windowConnections;
 };
 


### PR DESCRIPTION
Three functionalities backported from Qt 5.6, in order to get some of our WebView features back:
- custom background
- webengineprocess crash detection
- window.close signal
