### PR TITLE
GetScreenInfo: use default screen when no window is available

### DIFF
--- a/src/core/render_widget_host_view_qt.cpp
+++ b/src/core/render_widget_host_view_qt.cpp
@@ -666,9 +666,12 @@ void RenderWidgetHostViewQt::OnSwapCompositorFrame(uint32 output_surface_id, sco
 void RenderWidgetHostViewQt::GetScreenInfo(blink::WebScreenInfo* results)
 {
     QWindow* window = m_delegate->window();
-    if (!window)
-        return;
-    GetScreenInfoFromNativeWindow(window, results);
+    if( window ) {
+        GetScreenInfoFromNativeWindow(window, results);
+    }
+    else {
+        GetDefaultScreenInfo(results);
+    }
 
     // Support experimental.viewport.devicePixelRatio
     results->deviceScaleFactor *= dpiScale();


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
