### PR TITLE
Disable context menu

### DIFF
--- a/src/core/web_contents_view_qt.cpp
+++ b/src/core/web_contents_view_qt.cpp
@@ -133,6 +133,9 @@ static WebEngineContextMenuData fromParams(const content::ContextMenuParams &par
 
 void WebContentsViewQt::ShowContextMenu(content::RenderFrameHost *, const content::ContextMenuParams &params)
 {
+    // disable default context menu for LuneOS
+    return;
+
     WebEngineContextMenuData contextMenuData(fromParams(params));
     m_client->contextMenuRequested(contextMenuData);
 }


### PR DESCRIPTION
It should not be opened in new card; and even can crash the app.
Signed-off-by: Nikolay Nizov nizovn@gmail.com
