### PR TITLE
Enable explicitly Alsa and PulseAudio in Chromium, as it isn't set by…

### DIFF
--- a/src/core/config/embedded_linux.pri
+++ b/src/core/config/embedded_linux.pri
@@ -50,6 +50,8 @@ GYP_CONFIG += \
     v8_use_snapshot=false \
     want_separate_host_toolset=1 \
     enable_palmbridge=1 \
+    use_alsa=1 \
+    use_pulseaudio=1 \
 
 
 contains(QT_CONFIG, system-jpeg): GYP_CONFIG += use_system_libjpeg=1


### PR DESCRIPTION
… default for embedded devices

Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
