### PR TITLE
Fix dangling pointer problem

### DIFF
--- a/src/core/resource_dispatcher_host_delegate_qt.h
+++ b/src/core/resource_dispatcher_host_delegate_qt.h
@@ -73,7 +73,7 @@ private:
     int m_renderProcessId;
     int m_renderFrameId;
 
-    net::AuthChallengeInfo *m_authInfo;
+    scoped_refptr<net::AuthChallengeInfo> m_authInfo;
 
     // The request that wants login data.
     // Must only be accessed on the IO thread.


### PR DESCRIPTION
Turn the raw pointer
ResourceDispatcherHostLoginDelegateQt::m_authInfo
into a scoped_refptr, to prevent chromium from freeing the memory,
which caused this pointer to dangle and SEGFAULT upon later usage.

Task-number: QTBUG-55828
Change-Id: Ib57e89ca042a4494e2ab77ea10328495e6fc1431
Reviewed-by: Peter Varga pvarga@inf.u-szeged.hu
Reviewed-by: Michael Brüning michael.bruning@qt.io
