### PR TITLE
Implement RequestQuotePermission

### DIFF
--- a/src/core/content_browser_client_qt.cpp
+++ b/src/core/content_browser_client_qt.cpp
@@ -317,9 +317,14 @@ class QuotaPermissionContextQt : public content::QuotaPermissionContext {
 public:
     virtual void RequestQuotaPermission(const content::StorageQuotaParams &params, int render_process_id, const PermissionCallback &callback) Q_DECL_OVERRIDE
     {
-        Q_UNUSED(params);
         Q_UNUSED(render_process_id);
-        callback.Run(QUOTA_PERMISSION_RESPONSE_DISALLOW);
+
+        if((params.origin_url.SchemeIsFile() && params.requested_size < 64*1024*1024) ||  // local URL: 64MB
+            params.requested_size < 5*1024*1024) {                                        // remote URL: 5MB
+            callback.Run(QUOTA_PERMISSION_RESPONSE_ALLOW);
+        } else {
+            callback.Run(QUOTA_PERMISSION_RESPONSE_DISALLOW);
+        }
     }
 };
 


### PR DESCRIPTION
Allows 64MB for local URL, and 5MB otherwise.

Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
